### PR TITLE
Changed the node given that docker scout raised cybersecurity risks on the original version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Start your image with a node base image
-FROM node:18-alpine
+FROM node:lts-alpine3.21
 
 # The /app directory should act as the main application directory
 WORKDIR /app


### PR DESCRIPTION
Changed the node in Dockerfile to lts-alpine3.21, given that the last Alpine version had security issues.