### PR TITLE
Add MCP gateway and Playwright troubleshooting guide

### DIFF
--- a/TROUBLESHOOTING.txt
+++ b/TROUBLESHOOTING.txt
@@ -1,0 +1,71 @@
+## Docker MCP Gateway + Playwright Troubleshooting Guide
+
+### 1) Incident summary
+Two separate failures were identified:
+- **Playwright MCP startup failure** (`initialize: EOF`) after image pull failure.
+- **Gateway JSON parse failure** (`invalid character 'c' looking for beginning of value`) caused by sending shell text to a JSON-RPC stdin stream.
+
+### 2) Root causes
+- The Playwright image digest was missing locally due to a transient registry/DNS pull failure.
+- `docker mcp gateway run` expects JSON-RPC on stdin; plain commands are invalid input.
+
+### 3) Fix implemented
+- Pull required image:
+  - `docker pull mcp/playwright@sha256:b23ebe2ab08a54fffade79d2fceb4d36e1e17196c9d2e20fc4c4e91b0b6e28bc`
+- Verify server/tool availability:
+  - `docker mcp server list`
+  - `docker mcp tools list`
+- Verify tool execution:
+  - `docker mcp tools call mcp-find query=playwright`
+
+### 4) Standard operating model
+- **Terminal A:** `docker mcp gateway run` only.
+- **Terminal B:** all `docker mcp ...` commands.
+- Never type shell commands into gateway stdin.
+
+### 5) Troubleshooting checklist
+
+#### A. `initialize: EOF` / Playwright startup failure
+1. Check image:
+   - `docker image inspect mcp/playwright@sha256:b23ebe2ab08a54fffade79d2fceb4d36e1e17196c9d2e20fc4c4e91b0b6e28bc`
+2. If missing, pull again:
+   - `docker pull mcp/playwright@sha256:b23ebe2ab08a54fffade79d2fceb4d36e1e17196c9d2e20fc4c4e91b0b6e28bc`
+3. Re-check:
+   - `docker mcp tools list`
+   - `docker mcp server list`
+
+#### B. Pull/DNS/network issues
+1. Test Hub access:
+   - `docker pull hello-world:latest`
+2. Inspect Docker network/proxy config:
+   - `docker info`
+3. Retry the Playwright pull once connectivity stabilizes.
+
+#### C. JSON parser errors in gateway
+1. Stop gateway (`Ctrl+C`).
+2. Restart in a dedicated terminal.
+3. Ensure only JSON-RPC messages go to gateway stdin.
+
+#### D. JSON-RPC communication diagnostics
+1. Validate handshake:
+   - Send `initialize` first, then `tools/list`, then `tools/call`.
+2. Validate payload shape:
+   - Required keys: `jsonrpc`, `id`, `method` (and `params` when needed).
+3. Validate correlation:
+   - Response `id` must match request `id`.
+4. Check stream contamination:
+   - No shell prompts, banners, or plain text in stdin stream.
+5. Isolate client vs gateway:
+   - If `docker mcp tools call mcp-find query=playwright` works, gateway/server are healthy; client integration is likely the issue.
+6. Reduce concurrency during diagnosis:
+   - Send one request at a time to rule out ordering issues.
+7. Capture raw request/response logs:
+   - Compare failing payloads to a known-good call.
+
+### 6) Quick health check
+Run in a normal shell (not gateway stdin):
+- `docker mcp server list`
+- `docker mcp tools list`
+- `docker mcp tools call mcp-find query=playwright`
+
+If all pass, the MCP gateway + Playwright setup is healthy.

--- a/TROUBLESHOOTING.txt
+++ b/TROUBLESHOOTING.txt
@@ -69,3 +69,26 @@ Run in a normal shell (not gateway stdin):
 - `docker mcp tools call mcp-find query=playwright`
 
 If all pass, the MCP gateway + Playwright setup is healthy.
+
+### 7) Integration verification (final)
+Run this sequence to verify end-to-end integration:
+- `docker mcp server list`
+- `docker mcp tools list`
+- `docker mcp tools call mcp-find query=playwright`
+- `docker mcp tools call browser_navigate url=https://example.com`
+- `docker mcp tools call browser_take_screenshot`
+
+Expected outcomes:
+- Server list shows `playwright` enabled.
+- Tools list includes Playwright browser tools.
+- `mcp-find` returns `playwright` (and may also return `playwright-mcp-server` from catalog).
+- `browser_navigate` reports URL `https://example.com/` and title `Example Domain`.
+- `browser_take_screenshot` returns `image/png` output and a generated artifact path.
+
+### 8) Common command mistakes
+- Incorrect:
+  - `docker mcp tools call mcp-find query_name=playwright`
+- Correct:
+  - `docker mcp tools call mcp-find query=playwright`
+- Error symptom for wrong argument:
+  - `calling "tools/call": query parameter is required`


### PR DESCRIPTION
## Summary
- add `TROUBLESHOOTING.txt` with Docker MCP gateway and Playwright troubleshooting steps
- include JSON-RPC diagnostics and common command pitfalls
- document end-to-end verification commands for server, tools, search, navigation, and screenshot

## Validation
- docker mcp server list
- docker mcp tools list
- docker mcp tools call mcp-find query=playwright
- docker mcp tools call browser_navigate url=https://example.com
- docker mcp tools call browser_take_screenshot

Co-Authored-By: Oz <oz-agent@warp.dev>
